### PR TITLE
Unbreak black by updating it to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3


### PR DESCRIPTION
pre-commit hook breaks due to updated `click` package, that in turn breaks `black` due to incorrect exception handling.

Updating to black 22.3.0 fixes this issue, see also https://github.com/psf/black/issues/2964