### PR TITLE
Determine Sphinx docs version from `dissect.cobaltstrike._version`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ sys.path.insert(0, os.path.abspath("../"))
 # Get version info from dissect.cobaltstrike._version
 try:
     from dissect.cobaltstrike._version import version
+
     version, _, _ = version.partition("+")
     release = version
 except ModuleNotFoundError:
@@ -28,7 +29,6 @@ except ModuleNotFoundError:
 project = "dissect.cobaltstrike"
 copyright = "2022, NCC Group / Fox-IT"
 author = "NCC Group / Fox-IT"
-
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,13 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../"))
 
+# Get version info from dissect.cobaltstrike._version
+try:
+    from dissect.cobaltstrike._version import version
+    version, _, _ = version.partition("+")
+    release = version
+except ModuleNotFoundError:
+    release = version = "unknown"
 
 # -- Project information -----------------------------------------------------
 
@@ -22,8 +29,6 @@ project = "dissect.cobaltstrike"
 copyright = "2022, NCC Group / Fox-IT"
 author = "NCC Group / Fox-IT"
 
-# The full version, including alpha/beta/rc tags
-release = "0.1.0"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Instead of hardcoded docs release variable, determine from version written by setuptools_scm.