### PR TITLE
Apply black --check and --diff options via .pre-commit-config.yaml only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
+      args: [--check, --diff]
       language_version: python3
   - repo: https://gitlab.com/pycqa/flake8
     rev: 4.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,4 @@ write_to = "dissect/cobaltstrike/_version.py"
 
 [tool.black]
 line-length = 120
-diff = true
-check = true
 color = true


### PR DESCRIPTION
Removed the check and diff options from `pyproject.toml` so you can use black locally without enforced flags.