### PR TITLE
Ignore COMMAND_NOOP packets

### DIFF
--- a/dissect/cobaltstrike/client.py
+++ b/dissect/cobaltstrike/client.py
@@ -376,6 +376,9 @@ class HttpBeaconClient:
                 reason=response.reason_phrase,
             )
             for packet in self.c2http.iter_recover_http(req):
+                if packet.command == BeaconCommand.COMMAND_NOOP:
+                    logger.debug("Received NOOP packet: %s", packet)
+                    continue
                 return packet
         return None
 


### PR DESCRIPTION
If `data_jitter` is specified in the c2profile it will add random data to empty task responses.