### PR TITLE
Speed up finding non standard beacon XOR keys

### DIFF
--- a/dissect/cobaltstrike/beacon.py
+++ b/dissect/cobaltstrike/beacon.py
@@ -318,7 +318,7 @@ def iter_beacon_config_blocks(
     # Retry with left over xor keys if specified
     if not found and all_xor_keys:
         logger.debug("config_block not found, trying all xor keys...")
-        if xordecode:            
+        if xordecode:
             try:
                 fxor = XorEncodedFile.from_file(fobj)
             except ValueError:

--- a/dissect/cobaltstrike/beacon.py
+++ b/dissect/cobaltstrike/beacon.py
@@ -1,6 +1,7 @@
 """
 This module is responsible for extracting and parsing configuration from Cobalt Strike beacon payloads.
 """
+import collections
 import os
 import io
 import sys

--- a/dissect/cobaltstrike/beacon.py
+++ b/dissect/cobaltstrike/beacon.py
@@ -331,7 +331,7 @@ def iter_beacon_config_blocks(
         bytes_counter = collections.Counter()
         for chunk in iter(functools.partial(fxor.read, io.DEFAULT_BUFFER_SIZE), b""):
             fourgrams = grouper(chunk, n=4, fillvalue=0)
-            bytes_counter.update(gram[0] for gram in fourgrams if gram[0] == gram[1] == gram [2] == gram[3])
+            bytes_counter.update(gram[0] for gram in fourgrams if gram[0] == gram[1] == gram[2] == gram[3])
         most_common_bytes = [p8(x[0]) for x in bytes_counter.most_common()]
 
         # Sort left xor keys by most common bytes first

--- a/dissect/cobaltstrike/beacon.py
+++ b/dissect/cobaltstrike/beacon.py
@@ -330,7 +330,6 @@ def iter_beacon_config_blocks(
         # Determine most common bytes in the (xordecoded) file
         bytes_counter = collections.Counter()
         for chunk in iter(functools.partial(fxor.read, io.DEFAULT_BUFFER_SIZE), b""):
-            # bytes_counter.update(chunk)
             fourgrams = grouper(chunk, n=4, fillvalue=0)
             bytes_counter.update(gram[0] for gram in fourgrams if gram[0] == gram[1] == gram [2] == gram[3])
         most_common_bytes = [p8(x[0]) for x in bytes_counter.most_common()]

--- a/dissect/cobaltstrike/beacon.py
+++ b/dissect/cobaltstrike/beacon.py
@@ -318,7 +318,26 @@ def iter_beacon_config_blocks(
     # Retry with left over xor keys if specified
     if not found and all_xor_keys:
         logger.debug("config_block not found, trying all xor keys...")
+        if xordecode:            
+            try:
+                fxor = XorEncodedFile.from_file(fobj)
+            except ValueError:
+                fxor = fobj
+
+        # Determine left over xor keys
         left_xor_keys = make_byte_list(exclude=xor_keys)
+
+        # Determine most common bytes in the (xordecoded) file
+        bytes_counter = collections.Counter()
+        for chunk in iter(functools.partial(fxor.read, io.DEFAULT_BUFFER_SIZE), b""):
+            # bytes_counter.update(chunk)
+            fourgrams = grouper(chunk, n=4, fillvalue=0)
+            bytes_counter.update(gram[0] for gram in fourgrams if gram[0] == gram[1] == gram [2] == gram[3])
+        most_common_bytes = [p8(x[0]) for x in bytes_counter.most_common()]
+
+        # Sort left xor keys by most common bytes first
+        left_xor_keys.sort(key=lambda x: most_common_bytes.index(x) if x in most_common_bytes else 256)
+
         logger.debug(f"left xor keys to try: {left_xor_keys}")
         yield from iter_beacon_config_blocks(fobj, left_xor_keys, xordecode=xordecode, all_xor_keys=False)
 


### PR DESCRIPTION
When a beacon uses a non standard XOR key it would try each XOR key one by one. This change will perform some simple statistics on the data to determine the most likely XOR key candidates which significantly speeds up the process.