### PR TITLE
Switch to `ruff` linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,163 @@
+# dissect.cobaltstrike version.py
+dissect/cobaltstrike/_version.py
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: ruff
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
     - id: black
       args: [--check, --diff]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,14 @@
 repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.270
+    hooks:
+      - id: ruff
   - repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:
     - id: black
       args: [--check, --diff]
       language_version: python3
-  - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-bugbear]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:

--- a/dissect/cobaltstrike/artifact.py
+++ b/dissect/cobaltstrike/artifact.py
@@ -3,12 +3,11 @@ This module is responsible for dumping payloads from `ArtifactKit`_ generated ex
 
 .. _ArtifactKit: https://www.cobaltstrike.com/blog/what-is-a-stageless-payload-artifact/
 """
-import io
-import sys
-import logging
 import contextlib
-
-from typing import NamedTuple, BinaryIO, Iterator, Optional
+import io
+import logging
+import sys
+from typing import BinaryIO, Iterator, NamedTuple, Optional
 
 from dissect.cobaltstrike import utils
 

--- a/dissect/cobaltstrike/beacon.py
+++ b/dissect/cobaltstrike/beacon.py
@@ -2,26 +2,44 @@
 This module is responsible for extracting and parsing configuration from Cobalt Strike beacon payloads.
 """
 import collections
-import os
-import io
-import sys
-import time
+import functools
 import hashlib
-import logging
+import io
 import ipaddress
 import itertools
-import functools
+import logging
+import os
+import sys
+import time
 from collections import OrderedDict
 from types import MappingProxyType
-from typing import Any, BinaryIO, Dict, Callable, Iterator, List, Mapping, Optional, Tuple, Union, cast
+from typing import (
+    Any,
+    BinaryIO,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from dissect import cstruct
-
 from dissect.cobaltstrike import pe
+from dissect.cobaltstrike.utils import (
+    catch_sigpipe,
+    iter_find_needle,
+    p8,
+    u16be,
+    u32,
+    u32be,
+    xor,
+)
 from dissect.cobaltstrike.version import BeaconVersion
 from dissect.cobaltstrike.xordecode import XorEncodedFile
-from dissect.cobaltstrike.utils import catch_sigpipe, p8, u16be, u32, u32be
-from dissect.cobaltstrike.utils import xor, iter_find_needle
 
 logger = logging.getLogger(__name__)
 
@@ -1018,8 +1036,7 @@ def build_parser():
 @catch_sigpipe
 def main():
     """Entrypoint for beacon-dump."""
-    from . import c2profile
-    from . import utils
+    from . import c2profile, utils
 
     parser = build_parser()
     args = parser.parse_args()

--- a/dissect/cobaltstrike/c2.py
+++ b/dissect/cobaltstrike/c2.py
@@ -3,15 +3,15 @@ This module is responsible for working with Cobalt Strike C2 traffic.
 """
 # Python imports
 import base64
-import random
-import logging
 import hashlib
 import hmac
 import io
-from urllib.parse import urlparse, parse_qsl
+import logging
+import random
 
 # Typing imports
-from typing import List, Optional, Union, Tuple, NamedTuple, Iterator, Dict, overload
+from typing import Dict, Iterator, List, NamedTuple, Optional, Tuple, Union, overload
+from urllib.parse import parse_qsl, urlparse
 
 # Pycryptodome imports
 try:
@@ -30,14 +30,20 @@ except ImportError:
 
 # Local imports
 from dissect.cobaltstrike.beacon import BeaconConfig
-from dissect.cobaltstrike.utils import xor, p32be, netbios_encode, netbios_decode, namedtuple_reprlib_repr
 from dissect.cobaltstrike.c_c2 import (  # noqa: F401
-    c2struct,
+    BeaconCallback,
+    BeaconCommand,
+    BeaconMetadata,
     CallbackPacket,
     TaskPacket,
-    BeaconMetadata,
-    BeaconCommand,
-    BeaconCallback,
+    c2struct,
+)
+from dissect.cobaltstrike.utils import (
+    namedtuple_reprlib_repr,
+    netbios_decode,
+    netbios_encode,
+    p32be,
+    xor,
 )
 
 TransformStep = Tuple[str, Union[str, bytes, bool, int]]

--- a/dissect/cobaltstrike/c2.py
+++ b/dissect/cobaltstrike/c2.py
@@ -269,7 +269,7 @@ class HttpDataTransform:
         headers = request.headers
         body = request.body
         data: bytes = b""
-        for (step, step_val) in self.tsteps:
+        for step, step_val in self.tsteps:
             # logger.debug("transform step %r, %r", step, step_val)
             step = step.lower()
             if step == "append":
@@ -340,7 +340,7 @@ class HttpDataTransform:
         build_id = None
         data = b""
         # logger.debug("recover steps: %r", self.rsteps)
-        for (step, step_val) in self.rsteps:
+        for step, step_val in self.rsteps:
             step = step.lower()
             if step == "append":
                 if isinstance(step_val, bytes):

--- a/dissect/cobaltstrike/c2profile.py
+++ b/dissect/cobaltstrike/c2profile.py
@@ -2,13 +2,13 @@
 This module is responsible for parsing and generating Cobalt Strike Malleable C2 profiles.
 It uses the `lark-parser` library for parsing the syntax using the ``c2profile.lark`` grammar file.
 """
+import collections
+import logging
 import os
 import sys
-import logging
-import collections
 from typing import Any, List, Tuple, Union
 
-from lark import Lark, Tree, Token
+from lark import Lark, Token, Tree
 from lark.reconstruct import Reconstructor
 
 from dissect.cobaltstrike.beacon import BeaconConfig, BeaconSetting
@@ -764,6 +764,7 @@ def main():
     """Entrypoint for c2profile-dump."""
 
     import logging
+
     from dissect.cobaltstrike.beacon import BeaconConfig
 
     parser = build_parser()

--- a/dissect/cobaltstrike/client.py
+++ b/dissect/cobaltstrike/client.py
@@ -8,21 +8,21 @@ Beacon client that can actively connect to a Cobalt Strike Team Server.
 
 """
 # Python imports
-import sys
-import time
-import random
-import hashlib
-import string
-import urllib.parse
-import reprlib
-import inspect
 import argparse
 import datetime
+import hashlib
+import inspect
 import ipaddress
 import logging
+import random
+import reprlib
+import string
+import sys
+import time
+import urllib.parse
 
 # Typing imports
-from typing import Union, Optional, Tuple, Any, Dict, List, Callable
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 # Third party imports
 try:
@@ -39,18 +39,27 @@ except ImportError:
 
 # Local imports
 from dissect.cobaltstrike.c2 import (
+    BeaconCallback,
+    BeaconCommand,
     BeaconConfig,
+    BeaconMetadata,
     C2Data,
-    ClientC2Data,
     C2Http,
+    CallbackPacket,
+    ClientC2Data,
     HttpRequest,
     HttpResponse,
-    BeaconMetadata,
+    TaskPacket,
     c2packet_to_record,
+    encrypt_metadata,
+    encrypt_packet,
 )
-from dissect.cobaltstrike.c2 import TaskPacket, CallbackPacket, BeaconCommand, BeaconCallback
-from dissect.cobaltstrike.c2 import encrypt_metadata, encrypt_packet
-from dissect.cobaltstrike.utils import catch_sigpipe, p32be, p32, enable_reprlib_flow_record
+from dissect.cobaltstrike.utils import (
+    catch_sigpipe,
+    enable_reprlib_flow_record,
+    p32,
+    p32be,
+)
 
 logger = logging.getLogger(__name__)
 reprlib.aRepr.maxstring = 100
@@ -676,8 +685,8 @@ def parse_commandline_options(parser=None, defaults=None) -> Tuple[argparse.Name
 
     # Use rich logging if available
     try:
-        from rich.logging import RichHandler
         from rich.console import Console
+        from rich.logging import RichHandler
 
         logging.basicConfig(
             level=level,

--- a/dissect/cobaltstrike/client.py
+++ b/dissect/cobaltstrike/client.py
@@ -713,7 +713,6 @@ def parse_commandline_options(parser=None, defaults=None) -> Tuple[argparse.Name
 
 @catch_sigpipe
 def main():
-
     parser = build_parser()
     parser.add_argument(
         "--no-warning",

--- a/dissect/cobaltstrike/pcap.py
+++ b/dissect/cobaltstrike/pcap.py
@@ -365,7 +365,7 @@ def main():
     )
 
     with RecordWriter(args.writer) as writer:
-        for (packet, c2packet) in beacon_pcap:
+        for packet, c2packet in beacon_pcap:
             packet_record = packet_to_record(packet)
             record = c2packet_to_record(c2packet)
             record.raw_http = raw_http_from_packet(packet)

--- a/dissect/cobaltstrike/pcap.py
+++ b/dissect/cobaltstrike/pcap.py
@@ -1,18 +1,29 @@
-import os
-import sys
 import argparse
 import logging
+import os
+import sys
+from typing import Iterator, Optional, Tuple
 
-from typing import Optional, Tuple, Iterator
-
-from dissect.cobaltstrike.beacon import BeaconConfig
-from dissect.cobaltstrike.utils import catch_sigpipe, LRUDict, enable_reprlib_cstruct, enable_reprlib_flow_record
 from dissect.cobaltstrike import utils
-from dissect.cobaltstrike.c2 import C2Http, HttpRequest, HttpResponse, parse_raw_http, C2Packet, enable_reprlib_c2
-from dissect.cobaltstrike.c_c2 import BeaconMetadata, BeaconCommand, BeaconCallback
+from dissect.cobaltstrike.beacon import BeaconConfig
+from dissect.cobaltstrike.c2 import (
+    C2Http,
+    C2Packet,
+    HttpRequest,
+    HttpResponse,
+    enable_reprlib_c2,
+    parse_raw_http,
+)
+from dissect.cobaltstrike.c_c2 import BeaconCallback, BeaconCommand, BeaconMetadata
+from dissect.cobaltstrike.utils import (
+    LRUDict,
+    catch_sigpipe,
+    enable_reprlib_cstruct,
+    enable_reprlib_flow_record,
+)
 
 try:
-    from flow.record import RecordWriter, RecordDescriptor, extend_record, Record
+    from flow.record import Record, RecordDescriptor, RecordWriter, extend_record
 except ImportError:
     raise ImportError(
         "flow.record is required for writing Beacon records, please install it with `pip install flow.record`"

--- a/dissect/cobaltstrike/pe.py
+++ b/dissect/cobaltstrike/pe.py
@@ -3,7 +3,7 @@ This module contains helper functions for parsing PE files, mainly for extractin
 """
 import io
 import logging
-from typing import Optional, Tuple, BinaryIO
+from typing import BinaryIO, Optional, Tuple
 
 from dissect import cstruct
 

--- a/dissect/cobaltstrike/utils.py
+++ b/dissect/cobaltstrike/utils.py
@@ -1,18 +1,17 @@
 """
 This module contains generic helper functions used by ``dissect.cobaltstrike``.
 """
+import errno
 import io
 import os
-import re
-import sys
-import errno
 import random
-import string
+import re
 import reprlib
+import string
+import sys
 from collections import OrderedDict
-from functools import partial, wraps
 from contextlib import contextmanager
-
+from functools import partial, wraps
 from typing import BinaryIO, Iterator, NamedTuple
 
 

--- a/dissect/cobaltstrike/version.py
+++ b/dissect/cobaltstrike/version.py
@@ -9,10 +9,9 @@ Cobalt Strike version of beacon payloads.
     version estimate.
 """
 
-import re
 import datetime
-
-from typing import Dict, Tuple, Optional, Union
+import re
+from typing import Dict, Optional, Tuple, Union
 
 MAX_ENUM_TO_VERSION: Dict[int, str] = {
     20: "Cobalt Strike 3.4 (Jul 29, 2016)",

--- a/dissect/cobaltstrike/xordecode.py
+++ b/dissect/cobaltstrike/xordecode.py
@@ -2,15 +2,16 @@
 This module is responsible for decoding XorEncoded Cobalt Strike payloads.
 Not to be confused with the single byte XOR key that is used to obfuscate the beacon configuration block.
 """
-import io
-import os
-import sys
-import logging
 import collections
 import contextlib
+import io
+import logging
+import os
+import sys
 from typing import BinaryIO, Iterator, Union, cast
 
-from dissect.cobaltstrike.utils import catch_sigpipe, iter_find_needle, xor, u32
+from dissect.cobaltstrike.utils import catch_sigpipe, iter_find_needle, u32, xor
+
 from . import pe
 
 logger = logging.getLogger(__name__)
@@ -210,11 +211,11 @@ def main():
     logging.basicConfig(level=level)
 
     from .pe import (
+        find_architecture,
+        find_compile_stamps,
         find_magic_mz,
         find_magic_pe,
-        find_compile_stamps,
         find_stage_prepend_append,
-        find_architecture,
     )
 
     logger.info("Processing file: {!r}".format(args.input))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,59 @@ write_to = "dissect/cobaltstrike/_version.py"
 [tool.black]
 line-length = 120
 color = true
+
+[tool.ruff]
+line-length = 120
+select = [
+    "F",    # Pyflakes
+    "E",    # pycodestyle
+    "W",    # pycodestyle
+    #"C90",    # mccabe
+    "I",    # isort
+    #"N",    # pep8-naming
+    #"D",    # pydocstyle
+    #"UP",    # pyupgrade
+    "YTT",    # flake8-2020
+    #"ANN",    # flake8-annotations
+    "ASYNC",    # flake8-async
+    #"S",    # flake8-bandit
+    #"BLE",    # flake8-blind-except
+    #"FBT",    # flake8-boolean-trap
+    #"B",    # flake8-bugbear
+    #"A",    # flake8-builtins
+    #"COM",    # flake8-commas
+    #"C4",    # flake8-comprehensions
+    #"DTZ",    # flake8-datetimez
+    "T10",    # flake8-debugger
+    #"DJ",    # flake8-django
+    #"EM",    # flake8-errmsg
+    #"EXE",    # flake8-executable
+    "FA",    # flake8-future-annotations
+    "ISC",    # flake8-implicit-str-concat
+    "ICN",    # flake8-import-conventions
+    #"G",    # flake8-logging-format
+    #"INP",    # flake8-no-pep420
+    "PIE",    # flake8-pie
+    #"T20",    # flake8-print
+    "PYI",    # flake8-pyi
+    #"PT",    # flake8-pytest-style
+    "Q",    # flake8-quotes
+    "RSE",    # flake8-raise
+    #"RET",    # flake8-return
+    #"SLF",    # flake8-self
+    #"SIM",    # flake8-simplify
+    "TID",    # flake8-tidy-imports
+    "TCH",    # flake8-type-checking
+    "INT",    # flake8-gettext
+    #"ARG",    # flake8-unused-arguments
+    #"PTH",    # flake8-use-pathlib
+    "TD",    # flake8-todos
+    #"ERA",    # eradicate
+    #"PD",    # pandas-vet
+    #"PGH",    # pygrep-hooks
+    #"PL",    # Pylint
+    #"TRY",    # tryceratops
+    #"FLY",    # flynt
+    #"NPY",    # NumPy-specific
+    #"RUF",    # Ruff-specific
+]

--- a/scripts/checksum8-accesslogs.py
+++ b/scripts/checksum8-accesslogs.py
@@ -2,11 +2,11 @@
 #
 # Simple script to check the checksum8 of accesslogs
 #
-import re
-import sys
-import datetime
 import argparse
 import collections
+import datetime
+import re
+import sys
 
 from dissect.cobaltstrike import utils
 

--- a/scripts/dump_beacon_keys.py
+++ b/scripts/dump_beacon_keys.py
@@ -6,8 +6,9 @@
 #
 #   $ pip install javaobj-py3
 #
-import javaobj
 import base64
+
+import javaobj
 
 key = javaobj.loads(open(".cobaltstrike.beacon_keys", "rb").read())
 privkey_der = bytes(c & 0xFF for c in key.array.value.privateKey.encoded)

--- a/scripts/example_client.py
+++ b/scripts/example_client.py
@@ -11,11 +11,16 @@
 # Then run it for real in verbose mode:
 #  $ python3 example_client.py <beacon_file> -v
 #
-from io import BytesIO
 import textwrap
+from io import BytesIO
 
-from dissect.cobaltstrike.client import HttpBeaconClient, BeaconCallback, BeaconCommand, parse_commandline_options
-from dissect.cobaltstrike.client import CallbackOutputMessage
+from dissect.cobaltstrike.client import (
+    BeaconCallback,
+    BeaconCommand,
+    CallbackOutputMessage,
+    HttpBeaconClient,
+    parse_commandline_options,
+)
 from dissect.cobaltstrike.utils import p32be, u32be
 
 client = HttpBeaconClient()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,9 @@ import zipfile
 from contextlib import contextmanager
 from pathlib import Path
 
-from dissect.cobaltstrike import beacon
-
 import pytest
+
+from dissect.cobaltstrike import beacon
 
 beacons = {
     # x86 beacon

--- a/tests/test_beacon.py
+++ b/tests/test_beacon.py
@@ -1,12 +1,12 @@
-import io
-import sys
 import hashlib
+import io
 import subprocess
+import sys
 from unittest.mock import patch
 
-from dissect.cobaltstrike import beacon
-
 import pytest
+
+from dissect.cobaltstrike import beacon
 
 
 def test_beacon_from_file(beacon_x64_file):

--- a/tests/test_c2.py
+++ b/tests/test_c2.py
@@ -1,28 +1,32 @@
 import hmac
 import random
+
 import pytest
+from Crypto.PublicKey import RSA
 
 from dissect.cobaltstrike.beacon import BeaconConfig
 from dissect.cobaltstrike.c2 import (
-    C2Http,
-    HttpRequest,
-    HttpResponse,
-    BeaconMetadata,
-    TaskPacket,
-    BeaconCommand,
     BeaconCallback,
+    BeaconCommand,
+    BeaconKeys,
+    BeaconMetadata,
+    C2Http,
     ClientC2Data,
-    ServerC2Data,
     EncryptedPacket,
     HttpDataTransform,
-    BeaconKeys,
+    HttpRequest,
+    HttpResponse,
+    ServerC2Data,
+    TaskPacket,
+    decrypt_metadata,
+    decrypt_packet,
+    derive_aes_hmac_keys,
+    encrypt_data,
+    encrypt_metadata,
+    encrypt_packet,
+    pad,
     parse_raw_http,
 )
-from dissect.cobaltstrike.c2 import encrypt_metadata, encrypt_data, encrypt_packet
-from dissect.cobaltstrike.c2 import decrypt_metadata, decrypt_packet
-from dissect.cobaltstrike.c2 import derive_aes_hmac_keys, pad
-
-from Crypto.PublicKey import RSA
 
 # Test data sources:
 #  - https://www.malware-traffic-analysis.net/2021/02/02/index.html

--- a/tests/test_c2profile.py
+++ b/tests/test_c2profile.py
@@ -1,6 +1,4 @@
-from dissect.cobaltstrike import c2profile
-from dissect.cobaltstrike import beacon
-
+from dissect.cobaltstrike import beacon, c2profile
 
 C2PROFILE_SOURCE = """
 set jitter "100";

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,23 +1,28 @@
 import random
 import time
+from unittest.mock import PropertyMock, patch
 
 import pytest
-from unittest.mock import patch, PropertyMock
+from Crypto.PublicKey import RSA
 from pytest_httpserver import HTTPServer
 from werkzeug.wrappers import Request, Response
-from Crypto.PublicKey import RSA
 
 from dissect.cobaltstrike.beacon import BeaconConfig
+from dissect.cobaltstrike.c2 import (
+    decrypt_metadata,
+    decrypt_packet,
+    encrypt_packet,
+    parse_raw_http,
+)
 from dissect.cobaltstrike.c2profile import C2Profile
-from dissect.cobaltstrike.c2 import decrypt_metadata, encrypt_packet, parse_raw_http, decrypt_packet
 from dissect.cobaltstrike.client import (
-    CallbackDebugMessage,
-    HttpBeaconClient,
-    C2Data,
-    TaskPacket,
-    CallbackPacket,
-    BeaconCommand,
     BeaconCallback,
+    BeaconCommand,
+    C2Data,
+    CallbackDebugMessage,
+    CallbackPacket,
+    HttpBeaconClient,
+    TaskPacket,
     random_computer_name,
 )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -121,7 +121,7 @@ def test_client_get_task(request, task_file_list_packet, fixture_name, httpserve
         assert request.method == c2profile.properties["http-get.verb"].pop()
         assert request.path == c2profile.properties["http-get.uri"].pop()
         assert request.headers.get("User-Agent") == c2profile.properties["useragent"].pop()
-        for (header, value) in c2profile.properties.get("http-get.client.header", {}):
+        for header, value in c2profile.properties.get("http-get.client.header", {}):
             assert request.headers.get(header) == value
 
         # recover the GET request from the client
@@ -178,7 +178,7 @@ def test_client_post_callback(request, fixture_name, httpserver: HTTPServer):
         assert request.method == c2profile.properties["http-post.verb"].pop()
         assert request.path == c2profile.properties["http-post.uri"].pop()
         assert request.headers.get("User-Agent") == c2profile.properties["useragent"].pop()
-        for (header, value) in c2profile.properties["http-post.client.header"]:
+        for header, value in c2profile.properties["http-post.client.header"]:
             assert request.headers.get(header) == value
 
         # recover the POST request by the client

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -1,6 +1,4 @@
-from dissect.cobaltstrike import pe
-from dissect.cobaltstrike import beacon
-from dissect.cobaltstrike import xordecode
+from dissect.cobaltstrike import beacon, pe, xordecode
 
 
 def test_pe_beacon_x64(beacon_x64_file):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+
 from dissect.cobaltstrike import utils
 
 

--- a/tests/test_xordecode.py
+++ b/tests/test_xordecode.py
@@ -1,11 +1,9 @@
-import io
 import hashlib
-
-from dissect.cobaltstrike import pe
-from dissect.cobaltstrike import utils
-from dissect.cobaltstrike import xordecode
+import io
 
 import pytest
+
+from dissect.cobaltstrike import pe, utils, xordecode
 
 
 def test_xordecode(beacon_x86_file):


### PR DESCRIPTION
Change the pre-commit hook to use `ruff` instead of `flake8`.

For now only the `isort` linter has been enabled plus other ruff linters that did not cause any errors.