### PR TITLE
Pin dissect.cstruct < 4.0 for now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ namespace_packages = dissect
 platforms = any
 include_package_data = true
 install_requires =
-    dissect.cstruct >= 2.0
+    dissect.cstruct >= 2.0, < 4.0
     lark
 python_requires = >=3.7
 setup_requires =

--- a/tests/test_beacon.py
+++ b/tests/test_beacon.py
@@ -28,18 +28,18 @@ def test_beacon_from_file(beacon_x64_file):
 
 
 def test_beacon_from_path(beacon_x86_file, tmp_path):
-    with tmp_path / "beacon_x86.bin" as p:
-        p.write_bytes(beacon_x86_file.read())
-        bconfig = beacon.BeaconConfig.from_path(p)
-        assert len(bconfig.domains)
-        assert len(bconfig.uris)
-        assert bconfig.xorencoded
-        assert bconfig.protocol == "https"
+    p = tmp_path / "beacon_x86.bin"
+    p.write_bytes(beacon_x86_file.read())
+    bconfig = beacon.BeaconConfig.from_path(p)
+    assert len(bconfig.domains)
+    assert len(bconfig.uris)
+    assert bconfig.xorencoded
+    assert bconfig.protocol == "https"
 
-    with tmp_path / "bacon.bin" as p:
-        p.write_bytes(b"no bacon for you")
-        with pytest.raises(ValueError, match="No valid Beacon configuration found"):
-            beacon.BeaconConfig.from_path(p)
+    p = tmp_path / "bacon.bin"
+    p.write_bytes(b"no bacon for you")
+    with pytest.raises(ValueError, match="No valid Beacon configuration found"):
+        beacon.BeaconConfig.from_path(p)
 
 
 def test_beacon_from_bytes(beacon_x86_file):


### PR DESCRIPTION
Pin versions now until we have proper compatibility with `dissect.cstruct` v4.

related to #53 