### PR TITLE
Pin sphinx_rtd_theme>=2.0 to fix readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
     python: "3.10"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,11 +76,12 @@ test =
     dissect.cobaltstrike[full]
 docs =
     sphinx
-    sphinx_rtd_theme
+    sphinx_rtd_theme>=2.0
     sphinx-autoapi
     sphinx-copybutton
     sphinx-argparse-cli
     ipython
+    pickleshare
     dissect.cobaltstrike[full]
 
 [flake8]


### PR DESCRIPTION
It was somehow falling back to an really old version.

Also added pickleshare to silence ipython warnings during building of docs.