### PR TITLE
Update minimal Python requirement to 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.7", "pypy-3.8", "pypy-3.9"]
+        python-version: ["pypy-3.9", "pypy-3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Pypy ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Or install using the ``full`` extra to automatically install dependencies for C2
 
    $ pip install dissect.cobaltstrike[full]
 
-**dissect.cobaltstrike** requires Python 3.7 or later.
+**dissect.cobaltstrike** requires Python 3.9 or later.
 
 Documentation
 -------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,7 @@ The easiest way to install ``dissect.cobaltstrike`` is to use **pip**:
 
     $ pip install dissect.cobaltstrike
 
-Python 3.7 or higher is required and it has the following dependencies:
+Python 3.9 or higher is required and it has the following dependencies:
 
 * dissect.cstruct_ - for structure parsing
 * lark_ - for parsing malleable c2 profiles

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,11 +20,11 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Operating System :: Microsoft :: Windows
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Security
     Topic :: Utilities
     Topic :: Scientific/Engineering :: Information Analysis
@@ -42,7 +42,7 @@ include_package_data = true
 install_requires =
     dissect.cstruct >= 2.0, < 4.0
     lark
-python_requires = >=3.7
+python_requires = >=3.9
 setup_requires =
     setuptools_scm
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -243,11 +243,11 @@ def test_request_error(beacon_x86_bconfig, httpserver: HTTPServer, caplog):
 
     caplog.clear()
     client.get_task()
-    assert "ConnectError('[SSL: WRONG_VERSION_NUMBER] wrong version number" in caplog.text
+    assert "ConnectError('[SSL" in caplog.text
 
     caplog.clear()
     client.send_callback(*CallbackDebugMessage("hello"))
-    assert "ConnectError('[SSL: WRONG_VERSION_NUMBER] wrong version number" in caplog.text
+    assert "ConnectError('[SSL" in caplog.text
 
     # test connection to port that has no webserver running on -> ConnectError with connection refused
     client.run(bconfig=bconfig, sleeptime=0, dry_run=True, domain="127.0.0.1", port=0)


### PR DESCRIPTION
Also deprecate support for Python 3.7 and 3.8 and add Python 3.12 and 3.13 to test matrix.