### PR TITLE
Fix BeaconSetting names with unknown values

### DIFF
--- a/dissect/cobaltstrike/beacon.py
+++ b/dissect/cobaltstrike/beacon.py
@@ -794,7 +794,7 @@ class BeaconConfig:
         for setting in self.settings_tuple:
             val = setting.value
             if index_type == "name":
-                key = setting.index.name or str(setting.index)
+                key = setting.index.name or str(setting.index).replace(".", "_")
             elif index_type == "const":
                 key = setting.index.value
             else:

--- a/tests/test_beacon.py
+++ b/tests/test_beacon.py
@@ -314,12 +314,12 @@ def test_beacon_domains_punycode(punycode_beacon_file):
 
 
 def test_beacon_setting_unknown_enum():
-    setting = (
-        beacon.cs_struct.uint16(6969).dumps(),
-        beacon.SettingsType.TYPE_PTR.dumps(),
-        beacon.cs_struct.uint16(3).dumps(),
-        b"foo",
-    )
-    config = beacon.BeaconConfig(b"".join(setting))
+    data = beacon.Setting(
+        index=beacon.BeaconSetting(6969),
+        type=beacon.SettingsType.TYPE_PTR,
+        length=3,
+        value=b"foo",
+    ).dumps()
+    config = beacon.BeaconConfig(data)
     assert None not in config.settings
-    assert dict(config.settings) == {"BeaconSetting.6969": b"foo"}
+    assert dict(config.settings) == {"BeaconSetting_6969": b"foo"}


### PR DESCRIPTION
Ensure that unknown BeaconSetting names are the same as before, namely:

`BeaconSetting_<number>`

and not:

`BeaconSetting.<number>`