### PR TITLE
Speed up beacon file reading from zip files in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py3,pypy3
 [testenv]
 usedevelop = true
 extras = test
-commands = pytest --cov=dissect.cobaltstrike --cov-context=test --cov-report=xml {posargs}
+commands = pytest -v --cov=dissect.cobaltstrike --cov-context=test --cov-report=xml {posargs}
 
 [testenv:docs]
 extras = docs


### PR DESCRIPTION
The beacon file is now read from the zip archive and returned as a `BytesIO` object.
Before it would return the file handle from the zip archive which is significantly slower.