### PR TITLE
Update pip install docs with quoting when installing extras

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,11 @@ The library is available on `PyPI <https://pypi.org/project/dissect.cobaltstrike
 
 Or install using the ``full`` extra to automatically install dependencies for C2 and PCAP support::
 
-   $ pip install dissect.cobaltstrike[full]
+   $ pip install 'dissect.cobaltstrike[full]'
+
+If you want to install the latest pre-release version, use the ``--pre`` flag::
+
+   $ pip install --pre dissect.cobaltstrike
 
 **dissect.cobaltstrike** requires Python 3.9 or later.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,13 +19,22 @@ The following pip `extras` flavours are provided as well:
 
 .. code-block:: bash
 
-    $ pip install dissect.cobaltstrike[c2]
-    $ pip install dissect.cobaltstrike[pcap]
-    $ pip install dissect.cobaltstrike[full]
+    $ pip install 'dissect.cobaltstrike[c2]'
+    $ pip install 'dissect.cobaltstrike[pcap]'
+    $ pip install 'dissect.cobaltstrike[full]'
 
 * ``[c2]`` for if you want to communicate with Cobalt Strike Team Servers, eg: :doc:`tools/beacon-client`.
 * ``[pcap]`` for if you want to parse and decrypt PCAPS containing Beacon traffic, eg: :doc:`tools/beacon-pcap`.
 * ``[full]`` provides the above but also installs ``rich`` for prettier console logging.
+
+Install the latest pre-release version
+--------------------------------------
+
+Every change to the main branch is packaged and uploaded to PyPi as a pre-release version, to install the latest pre-release version use the ``--pre`` flag:
+
+.. code-block:: bash
+
+    $ pip install --pre dissect.cobaltstrike
 
 Installing from source
 ----------------------
@@ -36,7 +45,7 @@ If you want to install ``dissect.cobaltstrike`` from source, you can use the fol
 
      $ git clone https://github.com/fox-it/dissect.cobaltstrike.git
      $ cd dissect.cobaltstrike
-     $ pip install --editable .[full]
+     $ pip install --editable '.[full]'
 
 Using a virtual environment is recommended. Using the ``--editable`` flag ensures that any changes you make to the source code directly affects the installed package.
 

--- a/docs/tutorials/decrypt_cobaltstrike_pcaps.rst
+++ b/docs/tutorials/decrypt_cobaltstrike_pcaps.rst
@@ -26,7 +26,7 @@ First we ensure that we have ``dissect.cobaltstrike`` installed with PCAP suppor
 
 .. code-block:: bash
 
-   $ pip install dissect.cobaltstrike[pcap]
+   $ pip install 'dissect.cobaltstrike[pcap]'
 
 This also installs the ``pyshark`` Python package but it still requires the ``tshark`` binary from Wireshark_ to work.
 Ensure that you have Wireshark_ installed or install the ``tshark`` binary, for example on Ubuntu or Debian systems you can install it with:

--- a/docs/tutorials/minimal_beacon_client.rst
+++ b/docs/tutorials/minimal_beacon_client.rst
@@ -26,7 +26,7 @@ First we install ``dissect.cobaltstrike`` with the ``[c2]`` extra, as we are goi
 
 .. code-block:: bash
 
-    $ pip install dissect.cobaltstrike[c2]
+    $ pip install 'dissect.cobaltstrike[c2]'
 
 This installs the necessary dependencies such as `PyCryptodome` and `httpx`.
 


### PR DESCRIPTION
* This is to ensure that the example works on all shells, for example zsh.
* Also added example on how to install pre-release packages.