### PR TITLE
Fix failing readthedocs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,9 @@
 version: 2
 
+version: 2
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: ubuntu-lts-latest
   tools:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,5 @@
 version: 2
 
-version: 2
 sphinx:
   configuration: docs/conf.py
 


### PR DESCRIPTION
Added sphinx configuration to .readthedocs.yaml.

More info: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/