### PR TITLE
Update project dependencies and drop support for Python 3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,15 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.15.6
     hooks:
-      - id: ruff
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-    - id: black
-      args: [--check, --diff]
-      language_version: python3
+    - id: ruff          # used by `fix`
+      alias: ruff-fix
+      args: [--fix]
+    - id: ruff          # used by `lint`
+      alias: ruff-lint
+    - id: ruff-format   # replaces black
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.2
     hooks:
       - id: codespell
         args: [--ignore-words=docs/codespell-ignore-words.txt]

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ If you want to install the latest pre-release version, use the ``--pre`` flag::
 
    $ pip install --pre dissect.cobaltstrike
 
-**dissect.cobaltstrike** requires Python 3.9 or later.
+**dissect.cobaltstrike** requires Python 3.10 or later.
 
 Documentation
 -------------

--- a/dissect/cobaltstrike/beacon.py
+++ b/dissect/cobaltstrike/beacon.py
@@ -369,7 +369,7 @@ def iter_beacon_config_blocks(
     # Try XorEncoded files first as they are more common
     if not found and xordecode:
         try:
-            fxor = cast(BinaryIO, XorEncodedFile.from_file(fobj))
+            fxor = cast("BinaryIO", XorEncodedFile.from_file(fobj))
             for xorkey in xor_keys:
                 for config_block in find_beacon_config_bytes(fxor, xorkey):
                     found = True

--- a/dissect/cobaltstrike/guardrails.py
+++ b/dissect/cobaltstrike/guardrails.py
@@ -23,8 +23,9 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, BinaryIO
 
-from dissect.cobaltstrike.utils import grouper, u32be, xor
 from dissect.cstruct import cstruct
+
+from dissect.cobaltstrike.utils import grouper, u32be, xor
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -172,7 +173,6 @@ def payload_checksum(data: bytes) -> int:
 
 def iter_guardrail_configs_with_beacon(fh: BinaryIO) -> Iterator[GuardrailMetadata]:
     for grconfig in iter_guardrail_configs(fh):
-
         # Unmask the beacon config, static single byte xor key should be 0x2E unless modified beacon
         # The beacon config is still masked with the environmental key
         grconfig.beacon_xor_key = b"\x2e"  # we currently only support the XOR default key

--- a/dissect/cobaltstrike/pe.py
+++ b/dissect/cobaltstrike/pe.py
@@ -182,6 +182,7 @@ NT_SIGNATURE = c_pe.IMAGE_NT_SIGNATURE.to_bytes(4, "little")
 OS2_SIGNATURE = c_pe.IMAGE_OS2_SIGNATURE.to_bytes(4, "little")
 IMAGE_DOS_SIGNATURE = c_pe.IMAGE_DOS_SIGNATURE.to_bytes(2, "little")
 
+
 class LenientPE(PE):
     """Wrapper around :class:`dissect.executable.PE` that is lenient towards invalid PE signatures.
 
@@ -262,10 +263,6 @@ def find_compile_stamps(
         Tuple with ``(IMAGE_FILE_HEADER.TimeDateStamp, IMAGE_EXPORT_DIRECTORY.TimeDateStamp)``.
         Either tuple values can be ``None`` if it's not found.
     """
-    mz_offset = find_mz_offset(fh, start_offset=start_offset, maxrange=maxrange)
-    if mz_offset is None:
-        return (None, None)
-
     compile_stamp = None
     export_stamp = None
 

--- a/dissect/cobaltstrike/pe.py
+++ b/dissect/cobaltstrike/pe.py
@@ -8,6 +8,10 @@ import io
 import logging
 from typing import BinaryIO, Optional, Tuple
 
+from dissect.executable import PE
+from dissect.executable.pe.c_pe import c_pe
+from dissect.util.stream import OverlayStream, RangeStream
+
 from dissect import cstruct
 
 logger = logging.getLogger(__name__)
@@ -174,6 +178,38 @@ pestruct.load(PE_DEF)
 DOSHEADER_X64 = bytes.fromhex("554889e54881")
 DOSHEADER_X86 = bytes.fromhex("e8000000005b")
 
+NT_SIGNATURE = c_pe.IMAGE_NT_SIGNATURE.to_bytes(4, "little")
+OS2_SIGNATURE = c_pe.IMAGE_OS2_SIGNATURE.to_bytes(4, "little")
+IMAGE_DOS_SIGNATURE = c_pe.IMAGE_DOS_SIGNATURE.to_bytes(2, "little")
+
+class LenientPE(PE):
+    """Wrapper around :class:`dissect.executable.PE` that is lenient towards invalid PE signatures.
+
+    This is accomplished by using an OverlayStream to patch the PE signature when it's invalid.
+
+    It currently overlays the following fixes:
+
+        - Invalid PE signature (not "PE\0\0")
+        - Invalid MZ signature (not "MZ")
+    """
+
+    def __init__(self, fh: BinaryIO) -> None:
+        fh.seek(0)
+        mz_header = c_pe.IMAGE_DOS_HEADER(fh)
+        overlay = OverlayStream(fh, size=fh.seek(0, io.SEEK_END))
+        if mz_header.e_magic != c_pe.IMAGE_DOS_SIGNATURE:
+            logger.debug("Patching invalid MZ signature: %r -> %r", mz_header.e_magic, IMAGE_DOS_SIGNATURE)
+            overlay.add(0, IMAGE_DOS_SIGNATURE)
+            fh = overlay
+
+        fh.seek(mz_header.e_lfanew, io.SEEK_SET)
+        signature = fh.read(4)
+        if signature not in (NT_SIGNATURE, OS2_SIGNATURE):
+            logger.debug("Patching invalid PE signature: %r -> %r", signature, NT_SIGNATURE)
+            overlay.add(mz_header.e_lfanew, NT_SIGNATURE)
+            fh = overlay
+        super().__init__(fh)
+
 
 def find_mz_offset(fh: BinaryIO, start_offset: int = 0, maxrange: int = 1024) -> Optional[int]:
     """Find and return the start offset of a valid IMAGE_DOS_HEADER or ``None`` if it cannot be found.
@@ -232,29 +268,13 @@ def find_compile_stamps(
 
     compile_stamp = None
     export_stamp = None
-    fh.seek(mz_offset)
-    mz = pestruct.IMAGE_DOS_HEADER(fh)
-    fh.seek(mz.e_lfanew + mz_offset)
-    signature = pestruct.uint32(fh).to_bytes(4, "little")
-    logger.debug("PE signature: %r", signature)
-    image = pestruct.IMAGE_FILE_HEADER(fh)
-    compile_stamp = image.TimeDateStamp
-    if image.Machine == pestruct.IMAGE_FILE_MACHINE_AMD64:
-        optional_header = pestruct.IMAGE_OPTIONAL_HEADER64(fh)
-    else:
-        optional_header = pestruct.IMAGE_OPTIONAL_HEADER(fh)
-    export_dd = optional_header.DataDirectory[pestruct.IMAGE_DIRECTORY_ENTRY_EXPORT]
-    sections = [pestruct.IMAGE_SECTION_HEADER(fh) for _ in range(image.NumberOfSections)]
-    ds = None
-    for section in sections:
-        if section.VirtualAddress <= export_dd.VirtualAddress < (section.VirtualAddress + section.VirtualSize):
-            ds = section
-            break
-    if ds is not None:
-        offset = export_dd.VirtualAddress - ds.VirtualAddress + ds.PointerToRawData + mz_offset
-        fh.seek(offset)
-        export_dir = pestruct.IMAGE_EXPORT_DIRECTORY(fh)
-        export_stamp = export_dir.TimeDateStamp
+
+    mz_offset = find_mz_offset(fh, start_offset=start_offset, maxrange=maxrange)
+    if mz_offset is not None:
+        pe = LenientPE(RangeStream(fh, offset=mz_offset, size=None))
+        compile_stamp = int(pe.timestamp.timestamp())
+        export_stamp = int(pe.exports.timestamp.timestamp()) if pe.exports else None
+
     return (compile_stamp, export_stamp)
 
 

--- a/dissect/cobaltstrike/xordecode.py
+++ b/dissect/cobaltstrike/xordecode.py
@@ -118,7 +118,7 @@ class XorEncodedFile(io.RawIOBase):
             logger.debug(f"Found common nonce offset: {offset} ({count})")
             found_nonce_offset = offset
             xf = cls(fh, nonce_offset=found_nonce_offset)
-            if pe.find_mz_offset(cast(BinaryIO, xf)) is not None:
+            if pe.find_mz_offset(cast("BinaryIO", xf)) is not None:
                 xf.seek(0)
                 return xf
         raise ValueError(f"MZ header not found for: {fh}")

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -83,7 +83,7 @@ run tests with `checksum8` in the name including verbose and stdout logging:
 Linting
 -------
 
-For linting, run: 
+For linting, run:
 
 .. code-block:: shell
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,12 +7,16 @@ The easiest way to install ``dissect.cobaltstrike`` is to use **pip**:
 
     $ pip install dissect.cobaltstrike
 
-Python 3.9 or higher is required and it has the following dependencies:
+Python 3.10 or higher is required and it has the following dependencies:
 
 * dissect.cstruct_ - for structure parsing
+* dissect.executable_ - for PE parsing
+* dissect.util_ - for useful file stream functions
 * lark_ - for parsing malleable c2 profiles
 
 .. _dissect.cstruct: https://github.com/fox-it/dissect.cstruct
+.. _dissect.executable: https://github.com/fox-it/dissect.executable
+.. _dissect.util: https://github.com/fox-it/dissect.util
 .. _lark: https://github.com/lark-parser/lark
 
 The following pip `extras` flavours are provided as well:
@@ -79,11 +83,17 @@ run tests with `checksum8` in the name including verbose and stdout logging:
 Linting
 -------
 
-For linting (black and flake8):
+For linting, run: 
 
 .. code-block:: shell
 
      $ tox -e lint
+
+If there are any linting issues you can try to "fix" them using:
+
+.. code-block:: shell
+
+     $ tox -e fix
 
 Documentation
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,16 @@ build-backend = "hatchling.build"
 name = "dissect.cobaltstrike"
 dynamic = ["version"]
 description = "a Python library for dissecting Cobalt Strike related data"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "MIT License"}
 readme = "README.rst"
 authors = [
     {name = "Yun Zheng Hu", email = "hu@fox-it.com"},
 ]
 dependencies = [
-    "dissect.cstruct >= 4.6.dev",
+    "dissect.cstruct >= 4.7",
+    "dissect.executable >= 1.11",
+    "dissect.util >= 3.24",
     "lark",
 ]
 keywords = ["dissect", "cobaltstrike", "beacon", "parser", "parsing", "lark", "cstruct"]
@@ -28,11 +30,11 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security",
     "Topic :: Utilities",
     "Topic :: Scientific/Engineering :: Information Analysis",
@@ -73,6 +75,41 @@ docs = [
     "ipython",
     "pickleshare",
     "dissect.cobaltstrike[full]",
+]
+
+[dependency-groups]
+c2 = [
+    "flow.record",
+    "pycryptodome",
+    "httpx",
+]
+pcap = [
+    "pyshark",
+    {include-group = "c2"},
+]
+full = [
+    {include-group = "c2"},
+    {include-group = "pcap"},
+    "rich",
+]
+test = [
+    "pytest",
+    "pytest-cov",
+    "pytest-httpserver",
+    {include-group = "full"},
+]
+lint = [
+    "ruff",
+]
+docs = [
+    "sphinx",
+    "sphinx_rtd_theme>=2.0",
+    "sphinx-autoapi",
+    "sphinx-copybutton",
+    "sphinx-argparse-cli",
+    "ipython",
+    "pickleshare",
+    {include-group = "full"},
 ]
 
 [project.scripts]

--- a/tests/test_beacon.py
+++ b/tests/test_beacon.py
@@ -130,9 +130,7 @@ def test_setting_useragent_edgecase():
     00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
     00 00 00 00 00 00
-    """.replace(
-        "\n", ""
-    )
+    """.replace("\n", "")
     config = beacon.BeaconConfig(bytes.fromhex(data))
 
     ua = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; Win64; x64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)"  # noqa: E501
@@ -290,7 +288,7 @@ def test_main(capfdbinary, request, fixture, options, ret, stdout, stderr):
 def test_beacon_public_key(beacon_x86_file):
     bconfig = beacon.BeaconConfig.from_file(beacon_x86_file)
     assert bconfig.public_key == bytes.fromhex(
-        "30819f300d06092a864886f70d010101050003818d0030818902818100c9bc2d82418688a2e4f8d645ca54dacce652ef725189444fa2def7acfaf0b40000d45933eceb80e7fc1e1e2a540a3e96c2ffc22026369d0ff07da59898f1752593876f69a80b763042abbb92c52f8a85556c5f8e8b052060231684e007a866fc010f69f4c1d79e236b1b90cbc3861bf9b3a366cf5dac02d39519dafc717dece50203010001"  # noqa: 501
+        "30819f300d06092a864886f70d010101050003818d0030818902818100c9bc2d82418688a2e4f8d645ca54dacce652ef725189444fa2def7acfaf0b40000d45933eceb80e7fc1e1e2a540a3e96c2ffc22026369d0ff07da59898f1752593876f69a80b763042abbb92c52f8a85556c5f8e8b052060231684e007a866fc010f69f4c1d79e236b1b90cbc3861bf9b3a366cf5dac02d39519dafc717dece50203010001"  # noqa: E501
     )
     assert hashlib.sha256(bconfig.public_key).hexdigest() == bconfig.settings["SETTING_PUBKEY"]
 

--- a/tests/test_c2profile.py
+++ b/tests/test_c2profile.py
@@ -62,7 +62,7 @@ def test_c2profile_generator():
 
 
 def test_value_to_string():
-    val = b"\xCA\xFE\xBA\xBE"
+    val = b"\xca\xfe\xba\xbe"
     assert c2profile.value_to_string(val) == '"\\xca\\xfe\\xba\\xbe"'
     val = b"\x00\x22\x27"
     assert c2profile.value_to_string(val) == '"\\x00\\"\'"'

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ skip_install = true
 commands =
     pre-commit run codespell --all-files
     pre-commit run ruff-lint --all-files
+    pre-commit run ruff-format --all-files
 
 [testenv:fix]
 deps = pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,16 @@ commands =
 [testenv:lint]
 deps = pre-commit
 skip_install = true
-commands = pre-commit run --all-files
+commands =
+    pre-commit run codespell --all-files
+    pre-commit run ruff-lint --all-files
+
+[testenv:fix]
+deps = pre-commit
+skip_install = true
+commands =
+    pre-commit run ruff-fix --all-files
+    pre-commit run ruff-format --all-files
 
 [testenv:build]
 skip_install = true


### PR DESCRIPTION
We now depend on:

 * `dissect.executable` for easier PE parsing
 * `dissect.util` for RangeStream and OverlayStream

Also added `dependency-groups` for `uv` and improved linting and formatting.